### PR TITLE
Adding packages that are necessary to execute the tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ library(scLANE)
 library(ggplot2)
 library(scaffold)
 library(SingleCellExperiment)
+library(scRNAseq)
+library(scran)
+library(purrr)
+library(scater)
+library(igraph)
+library(caret)
+
 select <- dplyr::select
 ```
 


### PR DESCRIPTION
Some packages called during the tutorial or in the simulate_multi_subject() function were not listed.

Also, it would be a good idea to link the GitHub page of the package "scaffold", so people can easily find it to perform the installation.